### PR TITLE
docs: fix source_doc rendering (aligned tables, sub-sections)

### DIFF
--- a/doc/atcommands.md
+++ b/doc/atcommands.md
@@ -1455,7 +1455,11 @@ Unequip all items from a player.
 ```
 
 Give or remove a cart to a player and also change the cart skin based on ID:
-  0: remove cart
+
+```
+0: remove cart
+```
+
 1-5: normal carts
 6-9: new carts (available for PACKETVER >= 20120201)
 

--- a/doc/ea_job_system.md
+++ b/doc/ea_job_system.md
@@ -56,10 +56,9 @@ EAJ_GANGSI	0xB
 ```
 
 - Branch: All classes can be classified as "1st Class", "2-1 Class", "2-2 Class",
+  and then brought up to "3rd Class" and "4th Class":
 
 ```
-and then brought up to "3rd Class" and "4th Class":
-
 EAJL_2_1	0x100
 EAJL_2_2	0x200
 EAJL_2		0x300

--- a/doc/mapflags.md
+++ b/doc/mapflags.md
@@ -349,12 +349,8 @@ for 'Map' type 16 will be applied.
 
 This mapflag can also be used to adjust the damage of one skill by a percentage:
  - skill_name:
-
-```
-Name of the skill in 'db/(pre-)re/skill_db.yml' (ex. SM_BASH).
-To adjust all skill damage, write "all" (without quotes).
-```
-
+  Name of the skill in 'db/(pre-)re/skill_db.yml' (ex. SM_BASH).
+  To adjust all skill damage, write "all" (without quotes).
  - caster: the groups for which the adjustment takes effect. (bitmask)
 
 ```

--- a/doc/script_commands.md
+++ b/doc/script_commands.md
@@ -880,11 +880,10 @@ Unary operators with only with a single number, which follows the operator, and
 are following:
 
  -  - Negation.
+  The sign of the number will be reversed. If the number was positive, it will
+  become negative and vice versa.
 
 ```
-The sign of the number will be reversed. If the number was positive, it will
-become negative and vice versa.
-
 Example:
 	set .@myvar,10;
 	mes "Negative 10 is " + (-.@myvar);
@@ -9064,11 +9063,7 @@ Target flags:
 - bc_map: Message is sent to everyone in the same map as the source of the broadcast (see below).
 - bc_area: Message is sent to players in the vicinity of the source.
 - bc_self: Message is sent only to current player , if the source flag is bc_pc it also can
-
-```
-		be used to send the Message to the character id if it's provided.
-```
-
+  be used to send the Message to the character id if it's provided.
 You cannot use more than one target flag.
 
 Source flags:
@@ -14181,14 +14176,20 @@ setdialogalign(<align>);
 Set vertical or horizontal align in NPC dialog.
 Valid aligns:
 - horizontal align:
-  DIALOG_ALIGN_LEFT
-  DIALOG_ALIGN_CENTER
-  DIALOG_ALIGN_RIGHT
+
+```
+DIALOG_ALIGN_LEFT
+DIALOG_ALIGN_CENTER
+DIALOG_ALIGN_RIGHT
+```
 
 - vertical align:
-  DIALOG_ALIGN_TOP
-  DIALOG_ALIGN_MIDDLE
-  DIALOG_ALIGN_BOTTOM
+
+```
+DIALOG_ALIGN_TOP
+DIALOG_ALIGN_MIDDLE
+DIALOG_ALIGN_BOTTOM
+```
 
 ### setdialogsize
 

--- a/doc/source_doc.md
+++ b/doc/source_doc.md
@@ -24,28 +24,30 @@ The format of this file is as follows:
 The following terms will be frequently used throughout this file, so it is
 important to have a thorough understanding of what they are to avoid confusion.
 
-  Term          Description
-  ----          -----------
-  serv          a program/daemon that runs indefinitely offering a service
-  host          a machine that has one or more servs running
-  command       a request of an action on the server or client
-  (atcommand, script_command, packet_request)
-  interface     a class/module that offers a list of commands
+| Term | Description |
+|---|---|
+| serv | a program/daemon that runs indefinitely offering a service |
+| host | a machine that has one or more servs running |
+| command | a request of an action on the server or client (atcommand, script_command, packet_request) |
+| interface | a class/module that offers a list of commands |
 
 ## 2. Intro & Emulation
 
 rAthena is an emulation of Ragnarok Online, which runs on software known as AEGIS.
 AEGIS is separated into 4 servs:
 
-  Serv       Description
-  ----       -----------
-  account    handles player account information and logins.
-  char       handles character data (persistent information).
-  inter      handles broadcasting across map-serv. [merged into rAthena's char-serv]
-  map        handles all player runtime actions.
+| Serv | Description |
+|---|---|
+| account | handles player account information and logins. |
+| char | handles character data (persistent information). |
+| inter | handles broadcasting across map-serv. [merged into rAthena's char-serv] |
+| map | handles all player runtime actions. |
 
 These servs are an aggregation of each other:
-  login-serv  =>  1 - * char-serv, 1 - * map-serv
+
+```
+login-serv  =>  1 - * char-serv, 1 - * map-serv
+```
 
 In this case, * is 30. This means that 1 login-serv is able to manage up to
 30 char-serv, which itself can manage up to 30 map-serv. Note that due to these
@@ -80,66 +82,60 @@ and access it directly, but rather ask the char-serv to fetch it.
 The list below details the association of database tables with the servs.
 For real table names, see 'conf/inter_athena.conf'.
 
-  ==============
-  | Login-serv |
-  ==============
+### Login-serv
 
-  Table                 Contents
-  -----                 --------
-  login_db              all account-related information
-  reg_db                permanent account variables (ex. #CASHPOINTS)
+| Table | Contents |
+|---|---|
+| login_db | all account-related information |
+| reg_db | permanent account variables (ex. #CASHPOINTS) |
 
-  =============
-  | Char-serv |
-  =============
+### Char-serv
 
-  Table                 Contents
-  -----                 --------
-  char_db               all char-related information
-  hotkey_db             hotkeys set for each character
-  scdata_db             character status at disconnection
-  cart_db               list of items in each character's cart
-  inventory_db          list of items in each character's inventory
-  charlog_db            char-serv logs
-  storage_db            list of items in each character's storage (Kafra)
-  reg_db                permanent character variables (ex. ADVJOB)
-  skill_db              character learned skill database
-  interlog_db           inter-serv logs
-  memo_db               character Memo_point database
-  guild_db              guild record (name, master, lv, exp, emblem, etc.)
-  guild_alliance_db     guild relations database (allies, enemies)
-  guild_castle_db       guild owned castle database
-  guild_expulsion_db    guild expulsion logs
-  guild_member_db       guild current member titles and positions
-  guild_skill_db        guild learned skills database
-  guild_position_db     guild positions configuration (names, taxes, rights)
-  guild_storage_db      guild item storage
-  party_db              party record (name, leader, shared_exp, shared_item)
-  pet_db                saved pet objects database
-  friend_db             character friends database
-  mail_db               mail database
-  auction_db            auction database
-  quest_db              character quest realisation database
-  homunculus_db         saved homunculus objects database
-  skill_homunculus_db   homunculus learned skills database
-  mercenary_db          saved mercenary objects database (HP, SP, level, etc.)
-  mercenary_owner_db    character proprietary link to mercenary object save and use stats
-  elemental_db          saved Elemental objects database (HP, SP, FLEE, etc.)
-  ragsrvinfo_db         map-serv rate record (similar to 'conf/battle/drop.conf', possibly a leftover?)
-  skillcooldown_db      character skill cooldowns at disconnection
-  bonus_script_db       character bonus_script at disconnection
+| Table | Contents |
+|---|---|
+| char_db | all char-related information |
+| hotkey_db | hotkeys set for each character |
+| scdata_db | character status at disconnection |
+| cart_db | list of items in each character's cart |
+| inventory_db | list of items in each character's inventory |
+| charlog_db | char-serv logs |
+| storage_db | list of items in each character's storage (Kafra) |
+| reg_db | permanent character variables (ex. ADVJOB) |
+| skill_db | character learned skill database |
+| interlog_db | inter-serv logs |
+| memo_db | character Memo_point database |
+| guild_db | guild record (name, master, lv, exp, emblem, etc.) |
+| guild_alliance_db | guild relations database (allies, enemies) |
+| guild_castle_db | guild owned castle database |
+| guild_expulsion_db | guild expulsion logs |
+| guild_member_db | guild current member titles and positions |
+| guild_skill_db | guild learned skills database |
+| guild_position_db | guild positions configuration (names, taxes, rights) |
+| guild_storage_db | guild item storage |
+| party_db | party record (name, leader, shared_exp, shared_item) |
+| pet_db | saved pet objects database |
+| friend_db | character friends database |
+| mail_db | mail database |
+| auction_db | auction database |
+| quest_db | character quest realisation database |
+| homunculus_db | saved homunculus objects database |
+| skill_homunculus_db | homunculus learned skills database |
+| mercenary_db | saved mercenary objects database (HP, SP, level, etc.) |
+| mercenary_owner_db | character proprietary link to mercenary object save and use stats |
+| elemental_db | saved Elemental objects database (HP, SP, FLEE, etc.) |
+| ragsrvinfo_db | map-serv rate record (similar to 'conf/battle/drop.conf', possibly a leftover?) |
+| skillcooldown_db | character skill cooldowns at disconnection |
+| bonus_script_db | character bonus_script at disconnection |
 
-  ============
-  | Map-serv |
-  ============
+### Map-serv
 
-  Table                 Contents
-  -----                 --------
-  mapreg_db             permanent map-serv global variables (ex. $agit_result_timer)
-  buyingstore_db        live buyers database (map_pos, aid, shop title, etc.)
-  buyingstore_items_db  items currently being purchased by live buyers
-  vending_db            live vendors database (map_pos, aid, shop title, etc.)
-  vending_items_db      items currently being sold by live vendors
+| Table | Contents |
+|---|---|
+| mapreg_db | permanent map-serv global variables (ex. $agit_result_timer) |
+| buyingstore_db | live buyers database (map_pos, aid, shop title, etc.) |
+| buyingstore_items_db | items currently being purchased by live buyers |
+| vending_db | live vendors database (map_pos, aid, shop title, etc.) |
+| vending_items_db | items currently being sold by live vendors |
 
   The tables below are optional alternatives to TXT databases located in 'db/*.txt'.
 
@@ -162,143 +158,133 @@ For real table names, see 'conf/inter_athena.conf'.
 
 The following list describes each module and its purpose.
 
-  ============
-  | 3rdparty |
-  ============
+### 3rdparty
+
   The '3rdparty/' folder contains libraries used by the project but are not maintained by us.
 
-  ==========
-  | Common |
-  ==========
+### Common
+
   The 'src/common' folder contains all the modules which are used by more then 1 serv.
 
-  Module         Description
-  ------         -----------
-  cbasetypes     adapter to OS and arch specification (function name, bit representation)
-  cli            console Line Interface handling (get arguments from terminal at beginning and runtime)
-  conf           facade of libconfig api
-  core           MAIN program entry (initialization of each serv starts here)
-  db             database module (create, parse, and destroy databases)
-  des            Data Encryption Standard algorithm modified for rAthena
-  ers            Entry Reusage System to help memory allocation
-  grfio          handles *.grf files (searches for files in them and decodes them)
-  malloc         handles runtime memory allocation (so that memory manager could check for leaks)
-  mapindex       handles the processing and reading of the mapcache.dat
-  md5calc        offers md5 encryption
-  mmo.hpp        common structures and defines across serv
-  msg_conf       handles msg in src from configuration
-  nullpo         checks and dumps info for debug mode
-  random         generation of random numbers
-  showmsg        display messages in console with a certain color
-  socket         handling of sockets (listening, close, open, etc.)
-  sql.cpp        MySQL database proxy
-  strlib.cpp     string handling
-  timer.cpp      timer-related functions
-  utils.cpp      misc functions
-  winapi.hpp     Windows redefine and include
+| Module | Description |
+|---|---|
+| cbasetypes | adapter to OS and arch specification (function name, bit representation) |
+| cli | console Line Interface handling (get arguments from terminal at beginning and runtime) |
+| conf | facade of libconfig api |
+| core | MAIN program entry (initialization of each serv starts here) |
+| db | database module (create, parse, and destroy databases) |
+| des | Data Encryption Standard algorithm modified for rAthena |
+| ers | Entry Reusage System to help memory allocation |
+| grfio | handles *.grf files (searches for files in them and decodes them) |
+| malloc | handles runtime memory allocation (so that memory manager could check for leaks) |
+| mapindex | handles the processing and reading of the mapcache.dat |
+| md5calc | offers md5 encryption |
+| mmo.hpp | common structures and defines across serv |
+| msg_conf | handles msg in src from configuration |
+| nullpo | checks and dumps info for debug mode |
+| random | generation of random numbers |
+| showmsg | display messages in console with a certain color |
+| socket | handling of sockets (listening, close, open, etc.) |
+| sql.cpp | MySQL database proxy |
+| strlib.cpp | string handling |
+| timer.cpp | timer-related functions |
+| utils.cpp | misc functions |
+| winapi.hpp | Windows redefine and include |
 
-  ==============
-  | Login-serv |
-  ==============
+### Login-serv
 
-  Module         Description
-  ------         -----------
-  account            persistence for account data
-  ipban              offers IP banishment
-  login              main module of login-serv
-  loginclif          client `<=>` login-serv connections interface (send and receive packets to/from client)
-  loginchrif         char-serv `<=>` login-serv connections interface (send and receive packets to char-serv)
-  logincsnlif        console `<=>` login-serv connections interface (send and receive packets to/from console (internal buffer))
-  loginlog           records all operations into log for login-serv
+| Module | Description |
+|---|---|
+| account | persistence for account data |
+| ipban | offers IP banishment |
+| login | main module of login-serv |
+| loginclif | client `<=>` login-serv connections interface (send and receive packets to/from client) |
+| loginchrif | char-serv `<=>` login-serv connections interface (send and receive packets to char-serv) |
+| logincsnlif | console `<=>` login-serv connections interface (send and receive packets to/from console (internal buffer)) |
+| loginlog | records all operations into log for login-serv |
 
-  =============
-  | Char-serv |
-  =============
+### Char-serv
+
   The char-serv is responsible for persistence (save/load data permanently) and
   also serves as a controller that handles all associated map-servs. Further, it
   is responsible for ensuring that there are no duplicate party names among the
   map-servs (which could create conflicts if a party transfers map-servs).
 
-  Module             Description
-  ------             -----------
-  char               currently holds all the char-serv (EA) process
-  -- char_clif       client `<=>` char-serv connections interface (send and receive packets to/from client)
-  -- char_csnlif     console `<=>` char-serv connections interface (send and receive packets to/from console (internal buffer))
-  -- char_mapif      map-serv `<=>` char-serv connections interface (send and receive packets to map-serv)
-  -- char_logif      login-serv `<=>` char-serv connections interface (send and receive packets to login-serv)
-  inter              main entry to inter-serv; delegates packet handling to submodules
-  -- int_auction     handles auction request and saving
-  -- int_elemental   handles elemental data (BL_ELE => Sorcerer mob)
-  -- int_guild       handles guild data (creation, destruction, add member, etc.)
-  -- int_homun       handles homunculus data (BL_HOM => Alchemist mob)
-  -- int_mail        handles mail data
-  -- int_mercenary   handles mercenary data (BL_MER => All class mob)
-  -- int_party       handles party data (creation, destruction, add member, etc.)
-  -- int_pet         handles pet data (BL_PET => All class mob)
-  -- int_quest       handles quest data
-  -- int_storage     handles storage data (save storage, load storage, etc.)
+| Module | Description |
+|---|---|
+| char | currently holds all the char-serv (EA) process |
+| -- char_clif | client `<=>` char-serv connections interface (send and receive packets to/from client) |
+| -- char_csnlif | console `<=>` char-serv connections interface (send and receive packets to/from console (internal buffer)) |
+| -- char_mapif | map-serv `<=>` char-serv connections interface (send and receive packets to map-serv) |
+| -- char_logif | login-serv `<=>` char-serv connections interface (send and receive packets to login-serv) |
+| inter | main entry to inter-serv; delegates packet handling to submodules |
+| -- int_auction | handles auction request and saving |
+| -- int_elemental | handles elemental data (BL_ELE => Sorcerer mob) |
+| -- int_guild | handles guild data (creation, destruction, add member, etc.) |
+| -- int_homun | handles homunculus data (BL_HOM => Alchemist mob) |
+| -- int_mail | handles mail data |
+| -- int_mercenary | handles mercenary data (BL_MER => All class mob) |
+| -- int_party | handles party data (creation, destruction, add member, etc.) |
+| -- int_pet | handles pet data (BL_PET => All class mob) |
+| -- int_quest | handles quest data |
+| -- int_storage | handles storage data (save storage, load storage, etc.) |
 
-  ============
-  | Map-serv |
-  ============
+### Map-serv
 
-  Module         Description
-  ------         -----------
-  atcommand      handles GM commands (ex. @who)
-  battle         handles damage calculation where target is enemy and battle configuration settings
-  battleground   functions for Battleground system (create, destroy, messaging, join, etc.)
-  buyingstore    functions for player Buying Stores (create, search, sell)
-  cashshop       functions to set up the server cashshop (from cashshop_db), and contains function to buy items from cashshop
-  channel        functions for the channel system (create, delete, join/auto-join, leave, broadcast, alter options)
-  chat           functions for the chatroom system (create, delete, trigger chatroom_event, change owner, etc.)
-  chrif          char-serv `<=>` map-serv connections interface (send and receive packets to char-serv)
-  clif           client `<=>` map-serv connections interface (send and receive packets to/from client)
-  date           functions for time
-  duel           functions for the duel system
-  elemental      functions for Sorcerer Elementals processing (create, delete, etc.)
-  guild          functions for the guild system
-  homunculus     functions for Alchemist Homunculi processing (create, delete, get stats, death, etc.)
-  instance       functions for instance system
-  intif          map-serv `<=>` inter-serv interface (meant to communicate with 'char/inter.cpp' or its submodules)
-  itemdb         functions for the item database
-  log            functions for server log system
-  mail           functions for mail system
-  map            map-serv main module, and a representation of a map object
-  adds or removes other objects into map (blocklist) and provides iterators (ex. map_foreachpc)
-  mapreg         functions to save or read variables in mapreg_db (global variables for all map-serv)
-  mercenary      functions for Mercenary system (create, search, get stats, dead)
-  mob            functions for mob data, structures, and mob routines
-  npc            functions for NPC data (create, delete, calling NPCs)
-  npc_chat       functions for PCRE and NPC interaction
-  party          functions for the party system (create, join, delete, alter options, etc.)
-  path           functions for path finding (check_distance, search path unit will use)
-  pc             functions for player processing (loot/drop/delete items, player bonus handling, player dead, etc.)
-  pc_groups      functions for players groups system (manage player permissions and atcommand access)
-  pet            functions for the pet system (similar to mercenary, homunculus, player, etc.)
-  quest          functions for the quest log system (add, complete, remove, etc.)
-  script         handles script language logic (used in NPC scripts), script commands, and mapflags
-  searchstore    functions for the Vendor Shop Search feature
-  skill          functions for skills (skill_casttime calculation, skill behaviours, skill_chk_cast, requirement checks, 'db/skill_*.txt' processing)
-  status         functions for statuses on a bl (add, remove, calculation of effects as a temporary bonus)
-  status is a struct available by most units as common attributes (bl_type only attribute are dealt in bl specific files, like 'pc.cpp' or 'mob.cpp')
-  storage        functions for the storage system: Kafra, cart, guild, inventory (add, transfer, remove items between containers)
-  also ensures container mutex (e.g. guild_storage) and preparation for save requests
-  trade          functions to perform a trade (request, accept, add items/Zeny, checks, complete trade)
-  unit           functions for controlling player/mob/NPC actions (walk, follow, skill use)
-  vending        functions for Merchant Vending (create, purchase)
+| Module | Description |
+|---|---|
+| atcommand | handles GM commands (ex. @who) |
+| battle | handles damage calculation where target is enemy and battle configuration settings |
+| battleground | functions for Battleground system (create, destroy, messaging, join, etc.) |
+| buyingstore | functions for player Buying Stores (create, search, sell) |
+| cashshop | functions to set up the server cashshop (from cashshop_db), and contains function to buy items from cashshop |
+| channel | functions for the channel system (create, delete, join/auto-join, leave, broadcast, alter options) |
+| chat | functions for the chatroom system (create, delete, trigger chatroom_event, change owner, etc.) |
+| chrif | char-serv `<=>` map-serv connections interface (send and receive packets to char-serv) |
+| clif | client `<=>` map-serv connections interface (send and receive packets to/from client) |
+| date | functions for time |
+| duel | functions for the duel system |
+| elemental | functions for Sorcerer Elementals processing (create, delete, etc.) |
+| guild | functions for the guild system |
+| homunculus | functions for Alchemist Homunculi processing (create, delete, get stats, death, etc.) |
+| instance | functions for instance system |
+| intif | map-serv `<=>` inter-serv interface (meant to communicate with 'char/inter.cpp' or its submodules) |
+| itemdb | functions for the item database |
+| log | functions for server log system |
+| mail | functions for mail system |
+| map | map-serv main module, and a representation of a map object adds or removes other objects into map (blocklist) and provides iterators (ex. map_foreachpc) |
+| mapreg | functions to save or read variables in mapreg_db (global variables for all map-serv) |
+| mercenary | functions for Mercenary system (create, search, get stats, dead) |
+| mob | functions for mob data, structures, and mob routines |
+| npc | functions for NPC data (create, delete, calling NPCs) |
+| npc_chat | functions for PCRE and NPC interaction |
+| party | functions for the party system (create, join, delete, alter options, etc.) |
+| path | functions for path finding (check_distance, search path unit will use) |
+| pc | functions for player processing (loot/drop/delete items, player bonus handling, player dead, etc.) |
+| pc_groups | functions for players groups system (manage player permissions and atcommand access) |
+| pet | functions for the pet system (similar to mercenary, homunculus, player, etc.) |
+| quest | functions for the quest log system (add, complete, remove, etc.) |
+| script | handles script language logic (used in NPC scripts), script commands, and mapflags |
+| searchstore | functions for the Vendor Shop Search feature |
+| skill | functions for skills (skill_casttime calculation, skill behaviours, skill_chk_cast, requirement checks, 'db/skill_*.txt' processing) |
+| status | functions for statuses on a bl (add, remove, calculation of effects as a temporary bonus) status is a struct available by most units as common attributes (bl_type only attribute are dealt in bl specific files, like 'pc.cpp' or 'mob.cpp') |
+| storage | functions for the storage system: Kafra, cart, guild, inventory (add, transfer, remove items between containers) also ensures container mutex (e.g. guild_storage) and preparation for save requests |
+| trade | functions to perform a trade (request, accept, add items/Zeny, checks, complete trade) |
+| unit | functions for controlling player/mob/NPC actions (walk, follow, skill use) |
+| vending | functions for Merchant Vending (create, purchase) |
 
 ## 6. Nomenclature
 
 The following are standard naming conventions used by rAthena.
 
-  Type        Prefix         Example
-  ----        ------         -------
-  function    module_        pc_addspiritball -> located in pc.cpp file
-  structure   s_             s_quest_db
-  enum        e_             e_race
-  status      SC_            SC_INTOABYSS
-  skill       classmid_      AL_TELEPORT -> AL = Acolyte
-  bonus       SP_            SP_ATK_RATE
+| Type | Prefix | Example |
+|---|---|---|
+| function | module_ | pc_addspiritball -> located in pc.cpp file |
+| structure | s_ | s_quest_db |
+| enum | e_ | e_race |
+| status | SC_ | SC_INTOABYSS |
+| skill | classmid_ | AL_TELEPORT -> AL = Acolyte |
+| bonus | SP_ | SP_ATK_RATE |
 
 NOTES:
   - If a status name conflicts with a skill name, another '_' is added (e.g. SC__WEAKNESS).
@@ -311,30 +297,29 @@ NOTES:
 
 The following variables are commonly used in the source code.
 
-  Variable   Full Name            Description
-  --------   ---------            -----------
-  sd         session data         represents the session of a client into a serv (login, char, or map)
-  tsd        target sd            same as sd, but for a target
-  pl_sd                           usually in an iteration loop, the current sd of index
-  it_sd                           a variant of pl_sd (for iter_sd)
-  fd         file descriptor      a link to an I/O like a socket or file
-  md         mob data             represents monster information; also used to represent mercenary information
-  hd         homunculus data      represents homunculus information
-  nd         NPC data             represents NPC information
-  ed         elemental data       represents elemental information
-  pd         pet data             represents pet information
-  sc         status change        a structure containing all the possible status applied to a character
-  tsc        target sc            same as sc, but for a target
-  sce        status change entry  represents data of a specific inflicted status
-  bl         blocklist            common data of one object (a skill, pet, player, etc); also represents a 2-way chain-link
-  tbl        target bl            same as bl, but for a target
-  st         script stack         the stack of an NPC
-  aid        account id           a player account ID
-  gid        game id              the general unique ID of a Unit, which is the aid for players
-  (since a single character per account can be connected at one time)
-  cid        character id         a player character ID
-  rid        character id         a variant of cid
-  su         skill unit           a skill with a unit that remains on the ground
+| Variable | Full Name | Description |
+|---|---|---|
+| sd | session data | represents the session of a client into a serv (login, char, or map) |
+| tsd | target sd | same as sd, but for a target |
+| pl_sd |  | usually in an iteration loop, the current sd of index |
+| it_sd |  | a variant of pl_sd (for iter_sd) |
+| fd | file descriptor | a link to an I/O like a socket or file |
+| md | mob data | represents monster information; also used to represent mercenary information |
+| hd | homunculus data | represents homunculus information |
+| nd | NPC data | represents NPC information |
+| ed | elemental data | represents elemental information |
+| pd | pet data | represents pet information |
+| sc | status change | a structure containing all the possible status applied to a character |
+| tsc | target sc | same as sc, but for a target |
+| sce | status change entry | represents data of a specific inflicted status |
+| bl | blocklist | common data of one object (a skill, pet, player, etc); also represents a 2-way chain-link |
+| tbl | target bl | same as bl, but for a target |
+| st | script stack | the stack of an NPC |
+| aid | account id | a player account ID |
+| gid | game id | the general unique ID of a Unit, which is the aid for players (since a single character per account can be connected at one time) |
+| cid | character id | a player character ID |
+| rid | character id | a variant of cid |
+| su | skill unit | a skill with a unit that remains on the ground |
 
 ## 8. Building
 
@@ -374,10 +359,10 @@ ACMD_DEF(name)  - OR -  ACMD_DEFR(name,restriction)
 ACMD_DEF2("alias",name)  - OR -  ACMD_DEF2R("alias",name,restriction)
 ```
 
-  Restriction    Description
-  -----------    -----------
-  1          restrict usage in console
-  2          restrict usage in script_command
+| Restriction | Description |
+|---|---|
+| 1 | restrict usage in console |
+| 2 | restrict usage in script_command |
 
 ### Script Commands
 
@@ -392,25 +377,27 @@ BUILDIN_DEF(name,"arguments")
 BUILDIN_DEF2(name,"alias","arguments")
 ```
 
-  Argument    Description
-  --------    -----------
-  i        integer
-  s        string
-  v        variable
-  l        label
-  r        reference (of a variable)
-  ?        optional parameter (one)
-  *        optional parameter (unknown count)
-  null (no arguments)
+| Argument | Description |
+|---|---|
+| i | integer |
+| s | string |
+| v | variable |
+| l | label |
+| r | reference (of a variable) |
+| ? | optional parameter (one) |
+| * | optional parameter (unknown count) null (no arguments) |
 
 Useful functions:
-  script_hasdata(st,i);       // Returns if the stack contains data at the target index
-  script_getdata(st,i);       // Returns the script_data at the target index (data is a glob type)
-  script_getnum(st,val);      // Returns the int at the target index
-  script_getstr(st,val);      // Returns the string at the target index
-  script_getref(st,val);      // Returns the reference of a variable at the target index (useful for arrays, ex. 'checkweight2')
-  script_getfuncname(st);     // Returns the current function name (useful for function variants, ex. 'sc_start')
-  script_pushint(st,val);     // Pushes an int into the stack
-  script_pushstr(st,val);     // Pushes a string into the stack
-  script_isstring(st,i);      // Returns if the data at at the target index is a string
-  script_isint(st,i);         // Returns if the data at at the target index is an int
+
+```
+script_hasdata(st,i);       // Returns if the stack contains data at the target index
+script_getdata(st,i);       // Returns the script_data at the target index (data is a glob type)
+script_getnum(st,val);      // Returns the int at the target index
+script_getstr(st,val);      // Returns the string at the target index
+script_getref(st,val);      // Returns the reference of a variable at the target index (useful for arrays, ex. 'checkweight2')
+script_getfuncname(st);     // Returns the current function name (useful for function variants, ex. 'sc_start')
+script_pushint(st,val);     // Pushes an int into the stack
+script_pushstr(st,val);     // Pushes a string into the stack
+script_isstring(st,i);      // Returns if the data at at the target index is a string
+script_isint(st,i);         // Returns if the data at at the target index is an int
+```

--- a/tools/doc2md.py
+++ b/tools/doc2md.py
@@ -44,6 +44,12 @@ def is_code(line):
     return line.startswith("\t") or "\t" in line or line.startswith("    ")
 
 
+def looks_like_prose(text):
+    """A sentence rather than code or a key/value line."""
+    t = text.strip()
+    return len(t.split()) >= 5 and ";" not in t and "//" not in t and not re.match(r"^\S+\s*=", t)
+
+
 def is_dashes(line):
     return len(line) >= 3 and set(line) == {"-"}
 
@@ -93,6 +99,8 @@ DEFAULT_STYLE = (re.compile(r"^\*(?![*\s])"), False, True)
 SUBSECTION_RE = re.compile(r"^\*{1,2}\s+(\S.*)$")
 # 'nothing  - A permanent variable ...', '"#"  - ...', 'BaseClass - ...': hand-made definition lists
 DEFINITION_RE = re.compile(r"^(\S[^\s\t]{0,19})\s+-\s+(\S.*)$")
+TABLE_RULE_RE = re.compile(r"^\s*-{3,}(\s+-{3,})+\s*$")
+LIST_ITEM_RE = re.compile(r"^\s*(- |\d+[.)] )")
 OPERATOR_LINE_RE = re.compile(r"^([-+*])\s+-\s")
 
 
@@ -137,16 +145,66 @@ def convert(text, entry_style, converted_names):
     while i < n:
         line = lines[i].rstrip("\r")
 
-        # section banner: ===== / |Title| / =====
-        if is_equals(line) and i + 2 < n and lines[i + 1].startswith("|") and lines[i + 1].rstrip().endswith("|") and is_equals(lines[i + 2].rstrip()):
+        # section banner: ===== / |Title| / =====   (indented banners are sub-sections)
+        if is_equals(line.strip()) and i + 2 < n and lines[i + 1].strip().startswith("|") and lines[i + 1].rstrip().endswith("|") and is_equals(lines[i + 2].strip()):
             heading = lines[i + 1].strip().strip("|").strip()
             m = re.match(r"^(\d+(?:\.\d+)*)\.-?\s*(.*?)\.?$", heading)
             if m:
                 heading = f"{m.group(1)}. {m.group(2)}"
             blank()
-            out.append(f"## {heading}")
+            out.append(("### " if line.startswith((" ", "\t")) else "## ") + heading)
             out.append("")
             i += 3
+            continue
+
+        # aligned table: a header line followed by an underline row with one dash group per column
+        if i + 2 < n and TABLE_RULE_RE.match(lines[i + 1]) and lines[i + 2].strip() and line.strip() and not is_dashes(line.strip()):
+            rule = lines[i + 1].rstrip("\r")
+            starts = [m.start() for m in re.finditer(r"-{3,}", rule)]
+            def cells(text):
+                text = text.rstrip("\r").expandtabs(8)
+                return [text[a:b].strip() for a, b in zip(starts, starts[1:] + [None])]
+            header = cells(line)
+            rows = []
+            j = i + 2
+            while j < n and lines[j].strip() and not TABLE_RULE_RE.match(lines[j]) and not is_equals(lines[j].strip()):
+                row = cells(lines[j])
+                if rows and row and not row[0] and any(row):
+                    # continuation line: append to the last filled cell of the previous row
+                    k = max(idx for idx, c in enumerate(row) if c)
+                    rows[-1][k] = (rows[-1][k] + " " + row[k]).strip()
+                else:
+                    rows.append(row)
+                j += 1
+            blank()
+            esc = lambda c: prose(c, converted_names).replace("|", "\\|")
+            out.append("| " + " | ".join(esc(c) for c in header) + " |")
+            out.append("|" + "|".join("---" for _ in header) + "|")
+            for row in rows:
+                out.append("| " + " | ".join(esc(c) for c in row) + " |")
+            out.append("")
+            i = j
+            continue
+
+        # continuation of a list item or definition item: indented lines right after it (no blank line)
+        if line.startswith(("    ", "\t")) and out and (LIST_ITEM_RE.match(out[-1]) or out[-1].startswith("  ")) and lines[i - 1].strip() != "" and looks_like_prose(line):
+            out.append("  " + prose(line.strip(), converted_names))
+            i += 1
+            continue
+
+        # 'Useful functions:' / 'aggregation:' followed by 2-3 space indented code lines
+        if re.match(r"^ {2,3}\S", line) and not looks_like_prose(line) and not LIST_ITEM_RE.match(line) and (lines[i - 1].rstrip().endswith(":") or (out and out[-1] == "```" and False)):
+            block = []
+            j = i
+            while j < n and re.match(r"^ {2,}\S", lines[j]) and not looks_like_prose(lines[j]):
+                block.append(lines[j].rstrip("\r").strip())
+                j += 1
+            blank()
+            out.append("```")
+            out.extend(block)
+            out.append("```")
+            out.append("")
+            i = j
             continue
 
         # continuation of a definition item: indented lines right after it (no blank line)


### PR DESCRIPTION
Follow-up to #19: <https://danil0v3s.github.io/rathena/source_doc/> was still mangled — `source_doc.txt` is written with space-aligned tables (`Term   Description` over `----   -----------`), indented `|Title|` sub-banners and numbered items with indented explanations, all of which Markdown collapsed into run-on paragraphs.

### Converter (`tools/doc2md.py`)
- header line + dash-underline row with several column groups → Markdown table; continuation lines append to the previous row; a data row is required, so a two-word underlined title (`Assigning variables`) stays a title
- indented `|Title|` banners → `###` sub-sections
- indented text right after a list item continues the item when it reads as prose; indented code under a list item stays a code block (prose-vs-code heuristic)
- 2–3 space indented code after a line ending in `:` (`Useful functions:`) → fenced block

### Result
`source_doc.md`: 9 sections, 10 sub-sections, 13 tables. Small improvements on `mapflags`, `ea_job_system`, `atcommands`, `script_commands` from the same rules (explanations under list items no longer render as code). `mkdocs build --strict` clean; `tools/check-doc.pl` report unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
