### PR TITLE
ci: skip draft pull requests

### DIFF
--- a/.github/workflows/analysis_codeql.yml
+++ b/.github/workflows/analysis_codeql.yml
@@ -19,6 +19,7 @@ on:
       - 'CMakePresets.json'
       - 'vcpkg.json'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   changes:
@@ -62,7 +63,7 @@ jobs:
     needs: changes
     # Github Actions checks for '[ci skip]', '[skip ci]', '[no ci]', '[skip actions]', or '[actions skip]' but not a hyphenated version.
     # It's a catch-all incase a Pull Request has been opened and someone is on auto-pilot.
-    if: ${{ needs.changes.outputs.should_run == 'true' && !contains(github.event.head_commit.message, 'ci-skip') }}
+    if: ${{ needs.changes.outputs.should_run == 'true' && !contains(github.event.head_commit.message, 'ci-skip') && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -112,7 +113,7 @@ jobs:
     steps:
       - name: Enforce required CodeQL result
         run: |
-          if [ "${{ needs.changes.outputs.should_run }}" != "true" ]; then
+          if [ "${{ needs.changes.outputs.should_run }}" != "true" ] || [ "${{ github.event.pull_request.draft }}" = "true" ]; then
             echo "No relevant source or CI changes detected; skipping CodeQL."
             exit 0
           fi

--- a/.github/workflows/build_servers_linux.yml
+++ b/.github/workflows/build_servers_linux.yml
@@ -22,6 +22,7 @@ on:
       - 'CMakePresets.json'
       - 'vcpkg.json'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       # Always trigger all Github Actions if an action or something CI related was changed
       - '.github/**'
@@ -37,7 +38,7 @@ jobs:
   build:
     # Github Actions checks for '[ci skip]', '[skip ci]', '[no ci]', '[skip actions]', or '[actions skip]' but not a hyphenated version.
     # It's a catch-all incase a Pull Request has been opened and someone is on auto-pilot.
-    if: "!contains(github.event.head_commit.message, 'ci-skip')"
+    if: ${{ !contains(github.event.head_commit.message, 'ci-skip') && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build_servers_macos.yml
+++ b/.github/workflows/build_servers_macos.yml
@@ -21,6 +21,7 @@ on:
       - 'CMakePresets.json'
       - 'vcpkg.json'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       # Always trigger all Github Actions if an action or something CI related was changed
       - '.github/**'
@@ -36,7 +37,7 @@ jobs:
   build:
     # Github Actions checks for '[ci skip]', '[skip ci]', '[no ci]', '[skip actions]', or '[actions skip]' but not a hyphenated version.
     # It's a catch-all incase a Pull Request has been opened and someone is on auto-pilot.
-    if: "!contains(github.event.head_commit.message, 'ci-skip')"
+    if: ${{ !contains(github.event.head_commit.message, 'ci-skip') && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build_servers_packetversions.yml
+++ b/.github/workflows/build_servers_packetversions.yml
@@ -21,6 +21,7 @@ on:
       - 'CMakePresets.json'
       - 'vcpkg.json'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       # Always trigger all Github Actions if an action or something CI related was changed
       - '.github/**'
@@ -36,7 +37,7 @@ jobs:
   build:
     # Github Actions checks for '[ci skip]', '[skip ci]', '[no ci]', '[skip actions]', or '[actions skip]' but not a hyphenated version.
     # It's a catch-all incase a Pull Request has been opened and someone is on auto-pilot.
-    if: "!contains(github.event.head_commit.message, 'ci-skip')"
+    if: ${{ !contains(github.event.head_commit.message, 'ci-skip') && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build_servers_vip.yml
+++ b/.github/workflows/build_servers_vip.yml
@@ -21,6 +21,7 @@ on:
       - 'CMakePresets.json'
       - 'vcpkg.json'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       # Always trigger all Github Actions if an action or something CI related was changed
       - '.github/**'
@@ -36,7 +37,7 @@ jobs:
   build:
     # Github Actions checks for '[ci skip]', '[skip ci]', '[no ci]', '[skip actions]', or '[actions skip]' but not a hyphenated version.
     # It's a catch-all incase a Pull Request has been opened and someone is on auto-pilot.
-    if: "!contains(github.event.head_commit.message, 'ci-skip')"
+    if: ${{ !contains(github.event.head_commit.message, 'ci-skip') && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build_servers_windows.yml
+++ b/.github/workflows/build_servers_windows.yml
@@ -22,6 +22,7 @@ on:
       - 'CMakePresets.json'
       - 'vcpkg.json'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       # Always trigger all Github Actions if an action or something CI related was changed
       - '.github/**'
@@ -37,7 +38,7 @@ jobs:
   build:
     # Github Actions checks for '[ci skip]', '[skip ci]', '[no ci]', '[skip actions]', or '[actions skip]' but not a hyphenated version.
     # It's a catch-all incase a Pull Request has been opened and someone is on auto-pilot.
-    if: "!contains(github.event.head_commit.message, 'ci-skip')"
+    if: ${{ !contains(github.event.head_commit.message, 'ci-skip') && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -17,6 +17,7 @@ on:
       - 'tools/format.sh'
       - 'src/**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/**'
       - '.clang-format'
@@ -25,7 +26,7 @@ on:
 
 jobs:
   clang-format:
-    if: "!contains(github.event.head_commit.message, 'ci-skip')"
+    if: ${{ !contains(github.event.head_commit.message, 'ci-skip') && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,7 @@ on:
       - 'tools/mkdocs_hooks.py'
       - 'tools/doc2md.py'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/docs.yml'
       - 'doc/**'
@@ -32,6 +33,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/npc_db_validation.yml
+++ b/.github/workflows/npc_db_validation.yml
@@ -21,6 +21,7 @@ on:
       - 'db/**'
       - 'npc/**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       # Always trigger all Github Actions if an action or something CI related was changed
       - '.github/**'
@@ -33,7 +34,7 @@ jobs:
   build:
     # Github Actions checks for '[ci skip]', '[skip ci]', '[no ci]', '[skip actions]', or '[actions skip]' but not a hyphenated version.
     # It's a catch-all incase a Pull Request has been opened and someone is on auto-pilot.
-    if: "!contains(github.event.head_commit.message, 'ci-skip')"
+    if: ${{ !contains(github.event.head_commit.message, 'ci-skip') && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
All workflow jobs are skipped while a PR is a draft (`github.event_name != 'pull_request' || !github.event.pull_request.draft`), and `ready_for_review` is added to the PR trigger types so marking a draft ready starts the runs. The CodeQL required-status job treats a draft like "no relevant changes" so it does not block. Push-to-master behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)